### PR TITLE
QoL

### DIFF
--- a/src/Register.js
+++ b/src/Register.js
@@ -24,16 +24,17 @@ export default class Register extends Component {
         e.preventDefault();
         var username = this.inputName.value;
         var password = this.inputPassword.value;
-        var mail = this.inputEmail.value;
+        var email = this.inputeMail.value;
         axios.post(
             'http://localhost/quovis/src/api/?/user',
             {
                 user_name: username,
-                user_password: password
+                user_password: password,
+                user_email: email
             }
         ).then((response) => {
             console.log(response.data);
-            
+
         });
 
     }
@@ -51,7 +52,7 @@ export default class Register extends Component {
                             <input ref={node => this.inputName = node} placeholder="Användarnamn" className="form-control top" /><br/>
                             <input ref={node => this.inputPassword = node} placeholder="Lösenord" className="form-control"/><br/>
                             {/*<input ref={node => this.inputConfirmPass = node} placeholder="Bekräfta lösenord"/><br/>*/}
-                            <input ref={node => this.inputMail = node} placeholder="E-mailadress" className="form-control"/><br/>
+                            <input ref={node => this.inputeMail = node} placeholder="E-mailadress" className="form-control"/><br/>
                             <button className="btn btn-success" onClick={this.register}>Registrera ny användare</button>
                         </form>
                     </div>

--- a/src/api/config.php
+++ b/src/api/config.php
@@ -5,3 +5,4 @@ header('Access-Control-Allow-Methods: GET, POST, PUT, DELETE');
 header('Content-Type: application/json');
 
 $db = mysqli_connect('localhost', 'root', 'root', 'quovis');
+mysqli_query($db, "SET NAMES utf8");

--- a/src/api/user.resource.php
+++ b/src/api/user.resource.php
@@ -1,4 +1,16 @@
 <?php
+
+function fix($source) {
+    $source = preg_replace_callback(
+        '/(^|(?<=&))[^=[&]+/',
+        function($key) { return bin2hex(urldecode($key[0])); },
+        $source
+    );
+
+    parse_str($source, $post);
+    return array_combine(array_map('hex2bin', array_keys($post)), $post);
+}
+
 #
 # Den här klassen ska köras om vi anropat resursen user i vårt API genom /?/user
 #
@@ -45,6 +57,7 @@ class _user extends Resource{ // Klassen ärver egenskaper från den generella k
             $user = mysqli_fetch_assoc($result);
             $this->user_name = $user['user_name'];
             $this->user_password = $user['user_password'];
+            $this->user_email = $user['user_email'];
             
         }else{ // om vår URL inte innehåller ett ID hämtas alla users
             $query = "SELECT *
@@ -63,10 +76,15 @@ class _user extends Resource{ // Klassen ärver egenskaper från den generella k
         # I denna funktion skapar vi en ny user med den input vi fått
         $user_name = escape($input->user_name);
         $user_password = escape($input->user_password);
-        
+        $naughty_user_email = escape($input->user_email);
+
+        $bad_ending = array("_com", "_se", "_net", "_org", "_gov", "_eu");
+        $happy_ending   = array(".com", ".se", ".net", ".org", ".gov", ".eu");
+        $user_email = str_replace($bad_ending, $happy_ending, $naughty_user_email);
+
         $query = "INSERT INTO users
-        (user_name, user_password)
-        VALUES ('$user_name', '$user_password')";
+        (user_name, user_password, user_email)
+        VALUES ('$user_name', '$user_password', '$user_email')";
         
         mysqli_query($db, $query);
     }
@@ -80,7 +98,7 @@ class _user extends Resource{ // Klassen ärver egenskaper från den generella k
             
             $query = "
             UPDATE users
-            SET user_name = '$user_name', user_password = '$user_password'
+            SET user_name = '$user_name', user_password = '$user_password', 'user_email = '$user_email'
             WHERE user_id = $this->user_id
             ";
             mysqli_query($db, $query);
@@ -103,3 +121,4 @@ class _user extends Resource{ // Klassen ärver egenskaper från den generella k
     }
     
 }
+


### PR DESCRIPTION
- UTF8 on db
- New accounts has their e-mail adresses saved in a proper way to the db

***
Knowned issues;
Username and passwords containing "." are saved with "_" instead.
Save goes with e-mail, except for the last ".", i.e. ".com" or ".se"